### PR TITLE
Use fixed ports for Kubernetes deployment

### DIFF
--- a/templates/service/deployment/deployment.template.yml
+++ b/templates/service/deployment/deployment.template.yml
@@ -30,29 +30,34 @@ spec:
         image: quay.io/wercker/blueprint:${WERCKER_GIT_BRANCH}-${WERCKER_GIT_COMMIT}
         args: [
           "server",
-          "--metrics-port=9102",
         ]
         ports:
         - name: server
-          containerPort: 6666
+          containerPort: 8888
           protocol: TCP
         - name: metrics
           containerPort: 9102
           protocol: TCP
         env:
-          - name: MONGODB_URI
-            valueFrom:
-              secretKeyRef:
-                name: mongo
-                key: connectionstring
+        - name: PORT
+          value: 8888
+        - name: HEALTH_PORT
+          value: 9999
+        - name: METRICS_PORT
+          value: 9102
+        - name: MONGODB_URI
+          valueFrom:
+            secretKeyRef:
+              name: mongo
+              key: connectionstring
         livenessProbe:
           httpGet:
             path: /live
-            port: 6668
+            port: 9999
         readinessProbe:
           httpGet:
             path: /ready
-            port: 6668
+            port: 9999
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -71,8 +76,13 @@ spec:
         ]
         ports:
         - name: gateway
-          containerPort: 6667
+          containerPort: 8080
           protocol: TCP
+        env:
+        - name: HTTP_PORT
+          value: 8080
+        - name: GRPC_HOST
+          value: "localhost:8888"
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/templates/service/deployment/service.template.yml
+++ b/templates/service/deployment/service.template.yml
@@ -9,12 +9,12 @@ metadata:
 spec:
   ports:
     - name: server
-      port: 80
-      targetPort: 6666
+      port: 8888
+      targetPort: 8888
       protocol: TCP
     - name: gateway
       port: 8080
-      targetPort: 6667
+      targetPort: 8080
       protocol: TCP
     - name: http-metrics
       port: 9102


### PR DESCRIPTION
This will make sure that serivce has the same ports within a pod for the
gateway and server. This is set to 8888 for the gRPC server, 9999 for
the health server, 8080 for the gateway and 9012 for the metrics server.

Ports within the Kubernetes are already namespaced, so no need to keep them separate. This will make management of pods, services, and ingress easier as every port is the same. The current port numbers are up for debate. I avoided anything < 1024 as that would require root privileges.